### PR TITLE
Fix bug in metadata load process (incorrect track duration)

### DIFF
--- a/RxStreamPlayer.xcodeproj/project.pbxproj
+++ b/RxStreamPlayer.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6E0951871D2BED56005C4BD1 /* RxStreamPlayer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E09517C1D2BED56005C4BD1 /* RxStreamPlayer.framework */; };
+		6E38596A1D351B3500631969 /* MetadataTest2.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 6E3859691D351B3500631969 /* MetadataTest2.mp3 */; };
 		6E5B3CD81D2D089500775D9F /* NSURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3CD71D2D089500775D9F /* NSURL.swift */; };
 		6E5B3CDA1D2D08F900775D9F /* NSFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3CD91D2D08F900775D9F /* NSFileManager.swift */; };
 		6E5B3CDC1D2D094300775D9F /* Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3CDB1D2D094300775D9F /* Collection.swift */; };
@@ -16,13 +16,8 @@
 		6E5B3CE21D2D0F6200775D9F /* NSMutableOrderedSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3CE11D2D0F6200775D9F /* NSMutableOrderedSet.swift */; };
 		6E5B3CE41D2D16E800775D9F /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3CE31D2D16E800775D9F /* Dictionary.swift */; };
 		6E5B3D0B1D2D450000775D9F /* Fake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3D0A1D2D450000775D9F /* Fake.swift */; };
-		6E5B3D0C1D2D456000775D9F /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9A3AA01D2BF4BD00EC581E /* RxSwift.framework */; };
-		6E5B3D0F1D2D46F300775D9F /* RxHttpClient.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9A3AA81D2BF5EE00EC581E /* RxHttpClient.framework */; };
-		6E5B3D101D2D471B00775D9F /* Realm.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9A3AAC1D2BFD3800EC581E /* Realm.framework */; };
-		6E5B3D111D2D471B00775D9F /* RealmSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E9A3AAA1D2BFD0900EC581E /* RealmSwift.framework */; };
 		6E5B3D141D2D498200775D9F /* AssetResourceLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3CF21D2D44A200775D9F /* AssetResourceLoaderTests.swift */; };
 		6E5B3D161D2D4B4600775D9F /* DownloadManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5B3CF41D2D44A200775D9F /* DownloadManagerTests.swift */; };
-		6E5B3D1A1D2D4D9C00775D9F /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6E5B3D191D2D4D9C00775D9F /* RxBlocking.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		6E9A3A8A1D2BF49200EC581E /* AudioItemMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9A3A741D2BF49200EC581E /* AudioItemMetadata.swift */; };
 		6E9A3A8B1D2BF49200EC581E /* AVAssetResourceLoaderEventsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9A3A751D2BF49200EC581E /* AVAssetResourceLoaderEventsObserver.swift */; };
 		6E9A3A8C1D2BF49200EC581E /* DownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9A3A761D2BF49200EC581E /* DownloadManager.swift */; };
@@ -77,6 +72,7 @@
 		6E0951811D2BED56005C4BD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6E0951861D2BED56005C4BD1 /* RxStreamPlayerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RxStreamPlayerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6E09518D1D2BED56005C4BD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6E3859691D351B3500631969 /* MetadataTest2.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = MetadataTest2.mp3; sourceTree = "<group>"; };
 		6E5B3CD71D2D089500775D9F /* NSURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURL.swift; sourceTree = "<group>"; };
 		6E5B3CD91D2D08F900775D9F /* NSFileManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSFileManager.swift; sourceTree = "<group>"; };
 		6E5B3CDB1D2D094300775D9F /* Collection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Collection.swift; sourceTree = "<group>"; };
@@ -145,12 +141,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6E5B3D1A1D2D4D9C00775D9F /* RxBlocking.framework in Frameworks */,
-				6E5B3D101D2D471B00775D9F /* Realm.framework in Frameworks */,
-				6E5B3D111D2D471B00775D9F /* RealmSwift.framework in Frameworks */,
-				6E5B3D0F1D2D46F300775D9F /* RxHttpClient.framework in Frameworks */,
-				6E5B3D0C1D2D456000775D9F /* RxSwift.framework in Frameworks */,
-				6E0951871D2BED56005C4BD1 /* RxStreamPlayer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -252,6 +242,7 @@
 		6ECD090E1D2E7C0D0087180B /* Misc */ = {
 			isa = PBXGroup;
 			children = (
+				6E3859691D351B3500631969 /* MetadataTest2.mp3 */,
 				6ECD090F1D2E7C2D0087180B /* MetadataTest.mp3 */,
 			);
 			name = Misc;
@@ -357,6 +348,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6E38596A1D351B3500631969 /* MetadataTest2.mp3 in Resources */,
 				6ECD09101D2E7C2D0087180B /* MetadataTest.mp3 in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -575,6 +567,7 @@
 				INFOPLIST_FILE = RxStreamPlayer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.AntonEfimenko.RxStreamPlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -613,6 +606,7 @@
 				);
 				INFOPLIST_FILE = RxStreamPlayerTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = com.AntonEfimenko.RxStreamPlayerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";

--- a/RxStreamPlayer.xcodeproj/project.pbxproj
+++ b/RxStreamPlayer.xcodeproj/project.pbxproj
@@ -567,7 +567,7 @@
 				INFOPLIST_FILE = RxStreamPlayer/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				OTHER_SWIFT_FLAGS = "";
+				OTHER_SWIFT_FLAGS = "-D DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.AntonEfimenko.RxStreamPlayer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/RxStreamPlayer/RxPlayer+LoadMetadata.swift
+++ b/RxStreamPlayer/RxPlayer+LoadMetadata.swift
@@ -39,13 +39,17 @@ extension RxPlayer {
 		return Observable.create { [weak self] observer in
 			guard let object = self else { observer.onNext(Result.success(Box(value: nil))); observer.onCompleted(); return NopDisposable.instance }
 			
-			if let metadata = try! object.mediaLibrary.getMetadataObjectByUid(resource) {
+			// check metadata in media library
+			if let metadata = (try? object.mediaLibrary.getMetadataObjectByUid(resource)) ?? nil {
+				// if metadata exists, simply return it
 				observer.onNext(Result.success(Box(value: metadata)))
 				observer.onCompleted()
 				return NopDisposable.instance
 			}
 			
+			// check if requested resource existed in local storage as a file
 			if let localFile = object.downloadManager.fileStorage.getFromStorage(resource.streamResourceUid) {
+				// and if so, load metadata from that file
 				let metadata = object.loadFileMetadata(resource, file: localFile, utilities: utilities)
 				if let metadata = metadata {
 					object.mediaLibrary.saveMetadataSafe(metadata, updateExistedObjects: true)
@@ -56,22 +60,35 @@ extension RxPlayer {
 				return NopDisposable.instance
 			}
 			
+			// create AVURLAsset and set fake url in order to use "streaming"
+			let asset = utilities.createavUrlAsset(NSURL(baseUrl: "fake://test.com", parameters: nil)!)
+			let assetObserver = AVAssetResourceLoaderEventsObserver()
+			asset.getResourceLoader().setDelegate(assetObserver, queue: dispatch_get_global_queue(QOS_CLASS_UTILITY, 0))
 			let downloadObservable = downloadManager.createDownloadObservable(resource, priority: .Low)
 			
 			var receivedDataLen = 0
-			let disposable = downloadObservable.catchError { error in
+			
+			// start streaming data to AVURLAsset
+			let loadingDisposable = downloadObservable.catchError { error in
 					observer.onNext(Result.error(error))
 					observer.onCompleted()
 					return Observable.empty()
-				}.bindNext { e in
+				}.doOnNext { e in
 				if case Result.success(let box) = e {
 					if case StreamTaskEvents.CacheData(let prov) = box.value {
 						receivedDataLen = prov.getCurrentData().length
-						if receivedDataLen >= 1024 * 256 {
+						// if we reach maximum amoun of allowed data to download
+						// try to load metadata from file
+						// and after that dispose this download task
+						if receivedDataLen >= object.matadataMaximumLoadLength {
 							if let file = downloadManager.fileStorage.saveToTemporaryFolder(prov) {
 								let metadata = object.loadFileMetadata(resource, file: file, utilities: utilities)
 								if let metadata = metadata {
 									object.mediaLibrary.saveMetadataSafe(metadata, updateExistedObjects: true)
+									
+									#if DEBUG
+										NSLog("Metadata for \(resource.streamResourceUid) loaded. Maximum allowed data received: \(receivedDataLen)")
+									#endif
 								}
 								
 								observer.onNext(Result.success(Box(value: metadata)))
@@ -84,10 +101,31 @@ extension RxPlayer {
 					observer.onNext(Result.error(error))
 					observer.onCompleted()
 				}
+			}.loadWithAsset(assetEvents: assetObserver.loaderEvents, targetAudioFormat: resource.streamResourceContentType).subscribe()
+			
+			// load duration of asset async
+			// and when it's loaded, return metadata
+			asset.loadValuesAsynchronouslyForKeys(["duration"]) { [weak self] in
+				// AVAssetResourceLoader don't hold strong reference to delegate,
+				// so do it
+				let _ = assetObserver
+
+				var metadataArray = asset.getMetadata()
+				metadataArray["duration"] = asset.duration.safeSeconds
+				let audioMetadata = AudioItemMetadata(resourceUid: resource.streamResourceUid, metadata: metadataArray)
+				
+				self?.mediaLibrary.saveMetadataSafe(audioMetadata, updateExistedObjects: true)
+				
+				#if DEBUG
+					NSLog("Metadata for \(resource.streamResourceUid) loaded. Data received: \(receivedDataLen)")
+				#endif
+				
+				observer.onNext(Result.success(Box(value: audioMetadata)))
+				observer.onCompleted()
 			}
 			
 			return AnonymousDisposable {
-				disposable.dispose()
+				loadingDisposable.dispose()
 			}
 		}
 	}
@@ -104,7 +142,7 @@ extension RxPlayer {
 			let loadDisposable = items.toObservable().observeOn(serialScheduler)
 				.flatMap { item -> Observable<Result<MediaItemMetadataType?>> in
 					return object.loadMetadata(item)
-				}.doOnCompleted { print("batch metadata load completed"); observer.onCompleted() }.bindNext { result in
+				}.doOnCompleted { observer.onCompleted() }.bindNext { result in
 					if case Result.success(let box) = result, let meta = box.value {
 						observer.onNext(Result.success(Box(value: meta)))
 					} else if case Result.error(let error) = result {
@@ -113,8 +151,6 @@ extension RxPlayer {
 			}
 			
 			return AnonymousDisposable {
-				print("dispose batch metadata load")
-				//observer.onCompleted()
 				loadDisposable.dispose()
 			}
 		}

--- a/RxStreamPlayer/RxPlayer.swift
+++ b/RxStreamPlayer/RxPlayer.swift
@@ -41,6 +41,8 @@ public class RxPlayer {
 	internal let serialScheduler = SerialDispatchQueueScheduler(globalConcurrentQueueQOS: DispatchQueueSchedulerQOS.Utility)
 	internal var uiApplication: UIApplicationType?
 	internal var backgroundTaskIdentifier: Int?
+	/// Maximum amount of data that would me downloaded in order to retrieve metadata 
+	internal let matadataMaximumLoadLength = 1024 * 256
 	
 	internal lazy var eventsCallback: (PlayerEvents) -> () = {
 		return { [weak self] (event: PlayerEvents) in

--- a/RxStreamPlayer/SPExtensions.swift
+++ b/RxStreamPlayer/SPExtensions.swift
@@ -47,7 +47,7 @@ extension AVAssetResourceLoadingDataRequest : AVAssetResourceLoadingDataRequestP
 
 
 // AVAsset
-public protocol AVAssetProtocol {
+public protocol AVAssetProtocol : class {
 	var duration: CMTime { get }
 	func getMetadata() -> [String: AnyObject?]
 	func loadValuesAsynchronouslyForKeys(keys: [String], completionHandler: (() -> Void)?)
@@ -74,6 +74,7 @@ extension AVAsset: AVAssetProtocol {
 public protocol AVURLAssetProtocol: AVAssetProtocol {
 	var URL: NSURL { get }
 	func getResourceLoader() -> AVAssetResourceLoaderProtocol
+	func loadValuesAsynchronouslyForKeys(keys: [String], completionHandler: (() -> Void)?)
 }
 extension AVURLAsset: AVURLAssetProtocol {
 	public func getResourceLoader() -> AVAssetResourceLoaderProtocol {

--- a/RxStreamPlayerTests/AssetResourceLoaderTests.swift
+++ b/RxStreamPlayerTests/AssetResourceLoaderTests.swift
@@ -343,4 +343,22 @@ class AssetResourceLoaderTests: XCTestCase {
 		XCTAssertEqual(contentRequest1.contentLength, 22, "Check correct content length of first request")
 		XCTAssertEqual(contentRequest1.contentType, "public.mp3", "Check correct mime type of first")
 	}
+	
+	func testAvUrlAssetResourceLoaderUseDelegateWhenCustomSchemeProvided() {
+		let utilities = StreamPlayerUtilities()
+		let asset = utilities.createavUrlAsset(NSURL(baseUrl: "fake://test.com", parameters: nil)!)
+		let observer = AVAssetResourceLoaderEventsObserver()
+		asset.getResourceLoader().setDelegate(observer, queue: dispatch_get_global_queue(QOS_CLASS_UTILITY, 0))
+		
+		let expectation = expectationWithDescription("Should invoke resource loader observer methods")
+		
+		let bag = DisposeBag()
+		observer.loaderEvents.bindNext { event in
+			if case AssetLoadingEvents.shouldWaitForLoading = event { expectation.fulfill() }
+		}.addDisposableTo(bag)
+		
+		asset.loadValuesAsynchronouslyForKeys(["duration"], completionHandler: nil)
+		
+		waitForExpectationsWithTimeout(1, handler: nil)
+	}
 }

--- a/RxStreamPlayerTests/AssetResourceLoaderTests.swift
+++ b/RxStreamPlayerTests/AssetResourceLoaderTests.swift
@@ -359,6 +359,6 @@ class AssetResourceLoaderTests: XCTestCase {
 		
 		asset.loadValuesAsynchronouslyForKeys(["duration"], completionHandler: nil)
 		
-		waitForExpectationsWithTimeout(1, handler: nil)
+		waitForExpectationsWithTimeout(2, handler: nil)
 	}
 }

--- a/RxStreamPlayerTests/RxPlayerMetadataLoadTests.swift
+++ b/RxStreamPlayerTests/RxPlayerMetadataLoadTests.swift
@@ -19,16 +19,57 @@ class RxPlayerMetadataLoadTests: XCTestCase {
 		super.tearDown()
 	}
 	
+	/*
+	let dir = NSFileManager.getOrCreateSubDirectory(NSFileManager.documentsDirectory, subDirName: "DirSizeTest")!
+	
+	let firstData = "first data".dataUsingEncoding(NSUTF8StringEncoding)!
+	let secondData = "second data".dataUsingEncoding(NSUTF8StringEncoding)!
+	
+	let firstFile = dir.URLByAppendingPathComponent("first.dat")
+	firstData.writeToURL(firstFile, atomically: true)
+	*/
+	
 	func testLoadMetadataFromFile() {
 		let metadataFile = NSURL(fileURLWithPath: NSBundle(forClass: RxPlayerMetadataLoadTests.self).pathForResource("MetadataTest", ofType: "mp3")!)
+		let metaDataRaw = NSData(contentsOfURL: metadataFile)!
+		let subDataRaw = NSData(data: metaDataRaw.subdataWithRange(NSRange(location: 0, length: 1024 * 220)))
+		
+		let tempDir = NSFileManager.getOrCreateSubDirectory(NSFileManager.documentsDirectory, subDirName: NSUUID().UUIDString)!
+		let subDataFile = tempDir.URLByAppendingPathComponent("MetaDataTest.mp3")
+		subDataRaw.writeToURL(subDataFile, atomically: true)
+		
 		let player = RxPlayer()
 		let item = player.addLast("http://testitem.com")
-		let metadata = player.loadFileMetadata(item.streamIdentifier, file: metadataFile, utilities: StreamPlayerUtilities())
+		let metadata = player.loadFileMetadata(item.streamIdentifier, file: subDataFile, utilities: StreamPlayerUtilities())
 		XCTAssertEqual(metadata?.album, "Of Her")
 		XCTAssertEqual(metadata?.artist, "Yusuke Tsutsumi")
 		XCTAssertEqual(metadata?.duration?.asTimeString, "04: 27")
 		XCTAssertEqual(metadata?.title, "Love")
 		XCTAssertNotNil(metadata?.artwork)
+		
+		tempDir.deleteFile()
+	}
+	
+	func testLoadMetadataFromFile2() {
+		let metadataFile = NSURL(fileURLWithPath: NSBundle(forClass: RxPlayerMetadataLoadTests.self).pathForResource("MetadataTest2", ofType: "mp3")!)
+		let metaDataRaw = NSData(contentsOfURL: metadataFile)!
+		let subDataRaw = NSData(data: metaDataRaw.subdataWithRange(NSRange(location: 0, length: 1024 * 5)))
+		
+		let tempDir = NSFileManager.getOrCreateSubDirectory(NSFileManager.documentsDirectory, subDirName: NSUUID().UUIDString)!
+		let subDataFile = tempDir.URLByAppendingPathComponent("MetaDataTest2.mp3")
+		subDataRaw.writeToURL(subDataFile, atomically: true)
+		
+		
+		let player = RxPlayer()
+		let item = player.addLast("http://testitem.com")
+		let metadata = player.loadFileMetadata(item.streamIdentifier, file: subDataFile, utilities: StreamPlayerUtilities())
+		XCTAssertEqual(metadata?.album, "Red Dust & Spanish Lace")
+		XCTAssertEqual(metadata?.artist, "Acoustic Alchemy")
+		//XCTAssertEqual(metadata?.duration?.asTimeString, "03: 08")
+		XCTAssertEqual(metadata?.title, "Mr. Chow")
+		XCTAssertNil(metadata?.artwork)
+		
+		tempDir.deleteFile()
 	}
 	
 	func testNotLoadMetadataFromNotExistedFile() {

--- a/RxStreamPlayerTests/RxPlayerMetadataLoadTests.swift
+++ b/RxStreamPlayerTests/RxPlayerMetadataLoadTests.swift
@@ -19,24 +19,20 @@ class RxPlayerMetadataLoadTests: XCTestCase {
 		super.tearDown()
 	}
 	
-	/*
-	let dir = NSFileManager.getOrCreateSubDirectory(NSFileManager.documentsDirectory, subDirName: "DirSizeTest")!
-	
-	let firstData = "first data".dataUsingEncoding(NSUTF8StringEncoding)!
-	let secondData = "second data".dataUsingEncoding(NSUTF8StringEncoding)!
-	
-	let firstFile = dir.URLByAppendingPathComponent("first.dat")
-	firstData.writeToURL(firstFile, atomically: true)
-	*/
+	func createFileWithChunkData(file: NSURL, destinationDirectory: NSURL, location: Int, length: Int) -> NSURL {
+		let rawData = NSData(contentsOfURL: file)!
+		let subDataRaw = NSData(data: rawData.subdataWithRange(NSRange(location: location, length: length)))
+		
+		let subDataFile = destinationDirectory.URLByAppendingPathComponent("\(NSUUID().UUIDString).\(file.lastPathComponent ?? "dat")")
+		subDataRaw.writeToURL(subDataFile, atomically: true)
+		
+		return subDataFile
+	}
 	
 	func testLoadMetadataFromFile() {
 		let metadataFile = NSURL(fileURLWithPath: NSBundle(forClass: RxPlayerMetadataLoadTests.self).pathForResource("MetadataTest", ofType: "mp3")!)
-		let metaDataRaw = NSData(contentsOfURL: metadataFile)!
-		let subDataRaw = NSData(data: metaDataRaw.subdataWithRange(NSRange(location: 0, length: 1024 * 220)))
-		
 		let tempDir = NSFileManager.getOrCreateSubDirectory(NSFileManager.documentsDirectory, subDirName: NSUUID().UUIDString)!
-		let subDataFile = tempDir.URLByAppendingPathComponent("MetaDataTest.mp3")
-		subDataRaw.writeToURL(subDataFile, atomically: true)
+		let subDataFile = createFileWithChunkData(metadataFile, destinationDirectory: tempDir, location: 0, length: 1024 * 220)
 		
 		let player = RxPlayer()
 		let item = player.addLast("http://testitem.com")
@@ -52,13 +48,8 @@ class RxPlayerMetadataLoadTests: XCTestCase {
 	
 	func testLoadMetadataFromFile2() {
 		let metadataFile = NSURL(fileURLWithPath: NSBundle(forClass: RxPlayerMetadataLoadTests.self).pathForResource("MetadataTest2", ofType: "mp3")!)
-		let metaDataRaw = NSData(contentsOfURL: metadataFile)!
-		let subDataRaw = NSData(data: metaDataRaw.subdataWithRange(NSRange(location: 0, length: 1024 * 5)))
-		
 		let tempDir = NSFileManager.getOrCreateSubDirectory(NSFileManager.documentsDirectory, subDirName: NSUUID().UUIDString)!
-		let subDataFile = tempDir.URLByAppendingPathComponent("MetaDataTest2.mp3")
-		subDataRaw.writeToURL(subDataFile, atomically: true)
-		
+		let subDataFile = createFileWithChunkData(metadataFile, destinationDirectory: tempDir, location: 0, length: 1024 * 5)
 		
 		let player = RxPlayer()
 		let item = player.addLast("http://testitem.com")
@@ -165,7 +156,7 @@ class RxPlayerMetadataLoadTests: XCTestCase {
 		
 		let item = player.addLast("https://testitem.com")
 		
-		let metadataLoadExpectation = expectationWithDescription("Should load metadta from local file")
+		let metadataLoadExpectation = expectationWithDescription("Should load metadta from remote")
 		let downloadTaskCancelationExpectation = expectationWithDescription("Should cancel task")
 		
 		// simulate http request 
@@ -202,8 +193,99 @@ class RxPlayerMetadataLoadTests: XCTestCase {
 			}.addDisposableTo(bag)
 		
 		waitForExpectationsWithTimeout(2, handler: nil)
+		
+		// check if metadata correctly saved in media library
+		let track = try! player.mediaLibrary.getTrackByUid(item.streamIdentifier.streamResourceUid)
+		XCTAssertEqual(track?.album.name, "Of Her")
+		XCTAssertEqual(track?.artist.name, "Yusuke Tsutsumi")
+		XCTAssertEqual(track?.duration.asTimeString, "04: 27")
+		XCTAssertEqual(track?.title, "Love")
+		XCTAssertNotNil(track?.album.artwork)
 	}
 	
+	func testLoadChunkedMetadataFromRemote() {
+		let metadataFile = NSURL(fileURLWithPath: NSBundle(forClass: RxPlayerMetadataLoadTests.self).pathForResource("MetadataTest2", ofType: "mp3")!)
+		let metadataRawData = NSData(contentsOfURL: metadataFile)!
+		
+		let storage = LocalNsUserDefaultsStorage()
+		let streamObserver = NSURLSessionDataEventsObserver()
+		let httpUtilities = FakeHttpUtilities()
+		httpUtilities.streamObserver = streamObserver
+		let session = FakeSession(fakeTask: FakeDataTask(completion: nil))
+		httpUtilities.fakeSession = session
+		let downloadManager = DownloadManager(saveData: false, fileStorage: storage, httpUtilities: httpUtilities)
+		let player = RxPlayer(repeatQueue: false, shuffleQueue: false, downloadManager: downloadManager, streamPlayerUtilities: FakeStreamPlayerUtilities())
+		let item = player.addLast("https://testitem.com")
+		
+		let metadataLoadExpectation = expectationWithDescription("Should load metadta from remote")
+		let downloadTaskCancelationExpectation = expectationWithDescription("Should cancel task")
+		
+		var canceled = false
+		var sendedDataLength = 0
+		
+		// simulate http request
+		session.task?.taskProgress.observeOn(SerialDispatchQueueScheduler(globalConcurrentQueueQOS: DispatchQueueSchedulerQOS.Utility)).bindNext { e in
+			if case FakeDataTaskMethods.resume(let tsk) = e {
+				dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0)) {
+					let response = FakeResponse(contentLenght: Int64(metadataRawData.length))
+					response.MIMEType = "audio/mpeg"
+					streamObserver.sessionEventsSubject.onNext(.didReceiveResponse(session: session, dataTask: tsk,
+						response: response, completion: { _ in }))
+					
+					var currentOffset = 0
+					let sendDataChunk = 1024 * 5
+					while !canceled {
+						if metadataRawData.length - currentOffset > sendDataChunk {
+							let range = NSMakeRange(currentOffset, sendDataChunk)
+							currentOffset += sendDataChunk
+							sendedDataLength = currentOffset
+							let subdata = metadataRawData.subdataWithRange(range)
+							dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0)) {
+								streamObserver.sessionEventsSubject.onNext(.didReceiveData(session: session, dataTask: tsk, data: subdata))
+							}
+							NSThread.sleepForTimeInterval(0.005)
+						} else {
+							let range = NSMakeRange(currentOffset, metadataRawData.length - currentOffset)
+							let subdata = metadataRawData.subdataWithRange(range)
+							sendedDataLength = metadataRawData.length
+							dispatch_async(dispatch_get_global_queue(QOS_CLASS_UTILITY, 0)) {
+								streamObserver.sessionEventsSubject.onNext(.didReceiveData(session: session, dataTask: tsk, data: subdata))
+							}
+							break
+						}
+					}
+				}
+			} else if case FakeDataTaskMethods.cancel = e {
+				downloadTaskCancelationExpectation.fulfill()
+				canceled = true
+			}
+			}.addDisposableTo(bag)
+		
+		player.loadMetadata(item.streamIdentifier, downloadManager: downloadManager, utilities: StreamPlayerUtilities()).bindNext { result in
+			guard case Result.success(let box) = result else { return }
+			let metadata = box.value
+			XCTAssertEqual(metadata?.album, "Red Dust & Spanish Lace")
+			XCTAssertEqual(metadata?.artist, "Acoustic Alchemy")
+			XCTAssertEqual(metadata?.duration?.asTimeString, "03: 08")
+			XCTAssertEqual(metadata?.title, "Mr. Chow")
+			XCTAssertNil(metadata?.artwork)
+			
+			metadataLoadExpectation.fulfill()
+			}.addDisposableTo(bag)
+		
+		waitForExpectationsWithTimeout(4, handler: nil)
+		
+		XCTAssertTrue(sendedDataLength <= Int(Double(player.matadataMaximumLoadLength) * 1.05), "Check sended less data than was set as maximum limit for metadata gequests")
+		
+		// check if metadata correctly saved in media library
+		let track = try! player.mediaLibrary.getTrackByUid(item.streamIdentifier.streamResourceUid)
+		XCTAssertEqual(track?.album.name, "Red Dust & Spanish Lace")
+		XCTAssertEqual(track?.artist.name, "Acoustic Alchemy")
+		XCTAssertEqual(track?.duration.asTimeString, "03: 08")
+		XCTAssertEqual(track?.title, "Mr. Chow")
+		XCTAssertNil(track?.album.artwork)
+	}
+		
 	func testReturnErrorForItemWithUnknownScheme() {
 		let storage = LocalNsUserDefaultsStorage()
 		let downloadManager = DownloadManager(saveData: false, fileStorage: storage, httpUtilities: HttpUtilities())


### PR DESCRIPTION
Now use «streaming» for loading track metadata, it allows to correctly
get track length. As side effect in some situations it reduce amount of
used traffic.